### PR TITLE
Improvments to ult checking

### DIFF
--- a/CompareImages/IconLoader.cs
+++ b/CompareImages/IconLoader.cs
@@ -65,8 +65,8 @@ namespace CompareImages
             //Configure Filter
             _blobCounter.MinWidth = 50;
             _blobCounter.MinHeight = 50;
-            _blobCounter.MaxWidth = 100;
-            _blobCounter.MaxHeight = 100;
+            _blobCounter.MaxWidth = 120;
+            _blobCounter.MaxHeight = 120;
             _blobCounter.FilterBlobs = true;
 
             _blobCounter.ProcessImage(_bitmapBinaryImage);


### PR DESCRIPTION
Made max/min limits for the blob counter larger (need for 1920x1200)

Added and max / min check for the limit of the rectangles we get, this will exclude the bottom hero selected abilities

Added some percentile math to get all the rectangles are are close to each other. The old code was including some 1/2 ult pictures, these then were not matching correctly. I.e 1/2 Wind Ranger was matching to Kunkka

Added a debug mode that take a match id. This makes it easier to run a scenario and debug.
